### PR TITLE
🛠️ [FIX] Fixed nrows and ncols arguments

### DIFF
--- a/src/lib/components/DraggableDashboard.react.js
+++ b/src/lib/components/DraggableDashboard.react.js
@@ -15,7 +15,7 @@ import "../../../node_modules/react-grid-layout/css/styles.css"
 import "../../../node_modules/react-resizable/css/styles.css"
 import "./style.css"
 
-const defaultItemLayout = (item_layout, id, key, ncols) => {
+const defaultItemLayout = (item_layout, id, key, ncols, nrows) => {
     
     const nb_child_x = Math.floor(GRID_COLS / ncols)
     const col = (key % nb_child_x)
@@ -25,7 +25,7 @@ const defaultItemLayout = (item_layout, id, key, ncols) => {
         x: col * ncols,
         y: row,
         w: ncols,
-        h: NROWS
+        h: nrows
     }
     return {
         ...defaultChildLayout,
@@ -60,6 +60,7 @@ export default class DraggableDashboard extends Component {
             layout: providedLayout,
             clearSavedLayout,
             ncols = NCOLS,
+            nrows = NROWS
         } = this.props;
         let child_props, child_id, isDashboardItem;
         children = Array.isArray(children) ? children : [children]
@@ -106,10 +107,10 @@ export default class DraggableDashboard extends Component {
             }
             if (!item_layout && isDashboardItem){
                 const {id, x, y, w, h} = child_props
-                item_layout = defaultItemLayout({i:id, x, y, w, h}, child_id, key, ncols)
+                item_layout = defaultItemLayout({i:id, x, y, w, h}, child_id, key, ncols, nrows)
             }
             if (!item_layout){
-                item_layout = defaultItemLayout({}, child_id, key, ncols)
+                item_layout = defaultItemLayout({}, child_id, key, ncols, nrows)
             }
             // }
             // else {

--- a/src/lib/components/DraggableDashboardResponsive.react.js
+++ b/src/lib/components/DraggableDashboardResponsive.react.js
@@ -17,7 +17,7 @@ import './style.css';
 
 const ResponsiveReactGridLayout = widthProvider(Responsive);
 
-const defaultItemLayout = (item_layout, id, key, ncols, max_cols) => {
+const defaultItemLayout = (item_layout, id, key, ncols, nrows, max_cols) => {
     const nb_items_x = Math.floor(max_cols / ncols);
     const col = key % nb_items_x;
     const row = Math.floor(key / nb_items_x);
@@ -26,7 +26,7 @@ const defaultItemLayout = (item_layout, id, key, ncols, max_cols) => {
         x: col * ncols,
         y: row,
         w: ncols,
-        h: NROWS,
+        h: nrows,
     };
     return {
         ...defaultChildLayout,
@@ -61,6 +61,7 @@ export default class DraggableDashboardResponsive extends Component {
             layouts: providedLayouts,
             clearSavedLayout,
             ncols = NCOLS_RESPONSIVE,
+            nrows = NROWS,
             breakpoints = BREAKPOINTS,
             gridCols = GRID_COLS_RESPONSIVE,
         } = this.props;
@@ -132,6 +133,7 @@ export default class DraggableDashboardResponsive extends Component {
                         child_id,
                         key,
                         ncols[bkp],
+                        nrows,
                         gridCols[bkp]
                     );
                 }
@@ -141,6 +143,7 @@ export default class DraggableDashboardResponsive extends Component {
                         child_id,
                         key,
                         ncols[bkp],
+                        nrows,
                         gridCols[bkp]
                     );
                 }
@@ -305,7 +308,7 @@ DraggableDashboardResponsive.propTypes = {
      * ({breakpoint: number}) the default number of columns by item.
      * Default value is {lg: 6, md: 5, sm: 3, xs: 4, xxs: 2}.
      */
-    ncols: PropTypes.number,
+    ncols: PropTypes.object,
 
     /**
      * (number) the default number of row by item.

--- a/src/lib/components/GridLayout.react.js
+++ b/src/lib/components/GridLayout.react.js
@@ -9,7 +9,7 @@ import '../../../node_modules/react-grid-layout/css/styles.css';
 import '../../../node_modules/react-resizable/css/styles.css';
 import './style.css';
 
-const defaultItemLayout = (item_layout, id, key, ncols, gridCols) => {
+const defaultItemLayout = (item_layout, id, key, ncols, nrows, gridCols) => {
     const nb_child_x = Math.floor(gridCols / ncols);
     const col = key % nb_child_x;
     const row = Math.floor(key / nb_child_x);
@@ -18,7 +18,7 @@ const defaultItemLayout = (item_layout, id, key, ncols, gridCols) => {
         x: col * ncols,
         y: row,
         w: ncols,
-        h: NROWS,
+        h: nrows,
     };
     return {
         ...defaultChildLayout,
@@ -53,6 +53,7 @@ export default class GridLayout extends Component {
             layout: providedLayout,
             clearSavedLayout,
             ncols = NCOLS,
+            nrows = NROWS,
             gridCols = GRID_COLS,
         } = this.props;
         let child_props, child_id, isDashboardItem;
@@ -99,6 +100,7 @@ export default class GridLayout extends Component {
                     child_id,
                     key,
                     ncols,
+                    nrows,
                     gridCols
                 );
             }
@@ -108,6 +110,7 @@ export default class GridLayout extends Component {
                     child_id,
                     key,
                     ncols,
+                    nrows,
                     gridCols
                 );
             }

--- a/src/lib/components/ResponsiveGridLayout.react.js
+++ b/src/lib/components/ResponsiveGridLayout.react.js
@@ -17,7 +17,7 @@ import './style.css';
 
 const ResponsiveReactGridLayout = widthProvider(Responsive);
 
-const defaultItemLayout = (item_layout, id, key, ncols, max_cols) => {
+const defaultItemLayout = (item_layout, id, key, ncols, nrows, max_cols) => {
     const nb_items_x = Math.floor(max_cols / ncols);
     const col = key % nb_items_x;
     const row = Math.floor(key / nb_items_x);
@@ -26,7 +26,7 @@ const defaultItemLayout = (item_layout, id, key, ncols, max_cols) => {
         x: col * ncols,
         y: row,
         w: ncols,
-        h: NROWS,
+        h: nrows
     };
     return {
         ...defaultChildLayout,
@@ -61,6 +61,7 @@ export default class ResponsiveGridLayout extends Component {
             layouts: providedLayouts,
             clearSavedLayout,
             ncols = NCOLS_RESPONSIVE,
+            nrows = NROWS,
             breakpoints = BREAKPOINTS,
             gridCols = GRID_COLS_RESPONSIVE,
         } = this.props;
@@ -133,6 +134,7 @@ export default class ResponsiveGridLayout extends Component {
                         child_id,
                         key,
                         ncols[bkp],
+                        nrows,
                         gridCols[bkp]
                     );
                 }
@@ -142,6 +144,7 @@ export default class ResponsiveGridLayout extends Component {
                         child_id,
                         key,
                         ncols[bkp],
+                        nrows,
                         gridCols[bkp]
                     );
                 }
@@ -340,7 +343,7 @@ ResponsiveGridLayout.propTypes = {
      * ({breakpoint: number}) the default number of columns by item.
      * Default value is {lg: 6, md: 5, sm: 3, xs: 4, xxs: 2}.
      */
-    ncols: PropTypes.number,
+    ncols: PropTypes.object,
 
     /**
      * (number) the default number of row by item.


### PR DESCRIPTION
Nrows arguments of GridLayout and ResponsiveGridLayout are now taken into account instead of always using the
default value. Furthermore, the type of the ncols argument of ResponsiveGridLayout has been changed to object so that it accepts a dict with different values for each breakpoint according to the documentation.
The program was tested solely for our own use cases, which might differ from yours.

Closes #8